### PR TITLE
Fix broken test in Chai v4

### DIFF
--- a/test/timers.js
+++ b/test/timers.js
@@ -41,7 +41,7 @@ describe('Chai Timers', function () {
       timer.created.should.be.a('date');
 
       timer.should.have.property('elapsed')
-        .to.be.a('number').above('9');
+        .to.be.a('number').above(9);
       done();
     }, 10);
   });


### PR DESCRIPTION
In Chai v4, the `above` assertion no longer accepts strings, causing a
test to fail. This commit fixes the broken test by changing the string
`'9'` to the number `9`.